### PR TITLE
Dispersion with Tang-Toennies damping for any power

### DIFF
--- a/yaff/pes/pair_pot.c
+++ b/yaff/pes/pair_pot.c
@@ -400,15 +400,16 @@ double pair_fn_ljcross(void *pair_data, long center_index, long other_index, dou
 
 
 
-void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long* ffatype_ids, double *c6_cross, double *b_cross) {
+void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long power, long* ffatype_ids, double *cn_cross, double *b_cross) {
   pair_data_dampdisp_type *pair_data;
   pair_data = malloc(sizeof(pair_data_dampdisp_type));
   (*pair_pot).pair_data = pair_data;
   if (pair_data != NULL) {
     (*pair_pot).pair_fn = pair_fn_dampdisp;
     (*pair_data).nffatype = nffatype;
+    (*pair_data).power = power;
     (*pair_data).ffatype_ids = ffatype_ids;
-    (*pair_data).c6_cross = c6_cross;
+    (*pair_data).cn_cross = cn_cross;
     (*pair_data).b_cross = b_cross;
   }
 }
@@ -434,33 +435,34 @@ double tang_toennies(double x, int order, double *g){
 }
 
 double pair_fn_dampdisp(void *pair_data, long center_index, long other_index, double d, double *delta, double *g, double *g_cart) {
-  long i;
-  double b, disp, damp, c6;
+  long i,j,power;
+  double b, disp, damp, cn;
   // Load parameters from data structure and mix
   pair_data_dampdisp_type *pd;
   pd = (pair_data_dampdisp_type*)pair_data;
   i = (*pd).ffatype_ids[center_index]*(*pd).nffatype + (*pd).ffatype_ids[other_index];
-  c6 = (*pd).c6_cross[i];
-  if (c6==0.0) return 0.0;
+  power = (*pd).power;
+  cn = (*pd).cn_cross[i];
+  if (cn==0.0) return 0.0;
   b = (*pd).b_cross[i];
   if (b==0.0) {
     // without damping
-    disp = d*d;
-    disp *= disp*disp;
-    disp = -c6/disp;
+    disp = 1.0;
+    for (j=0;j<power;j++) { disp *= d; }
+    disp = -cn/disp;
     if (g != NULL) {
-      *g = -6.0*disp/(d*d);
+      *g = -power*disp/(d*d);
     }
     return disp;
   } else {
     // with damping
-    damp = tang_toennies(b*d, 6, g);
+    damp = tang_toennies(b*d, power, g);
     // compute the energy
-    disp = d*d;
-    disp *= disp*disp;
-    disp = -c6/disp;
+    disp = 1.0;
+    for (j=0;j<power;j++) { disp *= d; }
+    disp = -cn/disp;
     if (g != NULL) {
-      *g = ((*g)*b-6.0/d*damp)*disp/d;
+      *g = ((*g)*b-power/d*damp)*disp/d;
     }
     return damp*disp;
   }

--- a/yaff/pes/pair_pot.h
+++ b/yaff/pes/pair_pot.h
@@ -124,12 +124,13 @@ double pair_fn_ljcross(void *pair_data, long center_index, long other_index, dou
 
 typedef struct {
   long nffatype;
+  long power;
   long *ffatype_ids;
-  double *c6_cross;
+  double *cn_cross;
   double *b_cross;
 } pair_data_dampdisp_type;
 
-void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long* ffatype_ids, double *c6_cross, double *b_cross);
+void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long power, long* ffatype_ids, double *cn_cross, double *b_cross);
 double pair_fn_dampdisp(void *pair_data, long center_index, long other_index, double d, double *delta, double *g, double *g_cart);
 
 

--- a/yaff/pes/pair_pot.pxd
+++ b/yaff/pes/pair_pot.pxd
@@ -62,7 +62,7 @@ cdef extern from "pair_pot.h":
 
     void pair_data_ljcross_init(pair_pot_type *pair_pot, long nffatype, long* ffatype_ids, double *eps_cross, double *sig_cross)
 
-    void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long* ffatype_ids, double *c6_cross, double *b_cross)
+    void pair_data_dampdisp_init(pair_pot_type *pair_pot, long nffatype, long power, long* ffatype_ids, double *cn_cross, double *b_cross)
 
     void pair_data_disp68bjdamp_init(pair_pot_type *pair_pot, long nffatype, long* ffaype_ids, double *c6_cross, double *c8_cross, double *R_cross, double c6_scale, double c8_scale, double bj_a, double bj_b)
     double pair_data_disp68bjdamp_get_c6_scale(pair_pot_type *pair_pot)

--- a/yaff/pes/test/test_generator.py
+++ b/yaff/pes/test/test_generator.py
@@ -433,7 +433,7 @@ def test_generator_water32_dampdisp1():
     assert len(ff.parts) == 1
     part_pair_dampdisp = ff.part_pair_dampdisp
     # check parameters
-    c6_cross = part_pair_dampdisp.pair_pot.c6_cross
+    c6_cross = part_pair_dampdisp.pair_pot.cn_cross
     assert c6_cross.shape == (2,2)
     assert abs(c6_cross[0,0] - 1.9550248340e+01) < 1e-10
     assert abs(c6_cross[1,1] - 2.7982205915e+00) < 1e-10
@@ -458,7 +458,7 @@ def test_generator_water32_dampdisp2():
     assert len(ff.parts) == 1
     part_pair_dampdisp = ff.part_pair_dampdisp
     # check parameters
-    c6_cross = part_pair_dampdisp.pair_pot.c6_cross
+    c6_cross = part_pair_dampdisp.pair_pot.cn_cross
     assert abs(c6_cross[0,0] - 1.9550248340e+01) < 1e-10
     assert abs(c6_cross[0,1] - 6.4847208208e+00) < 1e-10
     assert abs(c6_cross[1,1] - 2.7982205915e+00) < 1e-10
@@ -479,7 +479,7 @@ def test_generator_glycine_dampdisp1():
     assert len(ff.parts) == 1
     part_pair_dampdisp = ff.part_pair_dampdisp
     # check parameters
-    c6_cross = part_pair_dampdisp.pair_pot.c6_cross
+    c6_cross = part_pair_dampdisp.pair_pot.cn_cross
     assert c6_cross.shape == (4, 4)
     assert abs(c6_cross[0,0] - 2.0121581791e+01) < 1e-10
     assert abs(c6_cross[1,1] - 2.5121581791e+01) < 1e-10
@@ -682,7 +682,7 @@ def test_generator_water32():
     part_ewald_cor = ff.part_ewald_cor
     part_ewald_neut = ff.part_ewald_neut
     # check dampdisp parameters
-    c6_cross = part_pair_dampdisp.pair_pot.c6_cross
+    c6_cross = part_pair_dampdisp.pair_pot.cn_cross
     assert abs(c6_cross[0,0] - 1.9550248340e+01) < 1e-10
     assert abs(c6_cross[1,1] - 2.7982205915e+00) < 1e-10
     assert (c6_cross == c6_cross.T).all()

--- a/yaff/pes/test/test_pair_pot.py
+++ b/yaff/pes/test/test_pair_pot.py
@@ -830,49 +830,59 @@ def test_pair_pot_ljcross_caffeine_9A():
     check_pair_pot_caffeine(system, nlist, scalings, part_pair, pair_fn, 1e-15)
 
 
-def get_part_caffeine_dampdisp_9A():
+def get_part_caffeine_dampdisp_9A(power=6):
     # Get a system and define scalings
     system = get_system_caffeine()
     nlist = NeighborList(system)
     scalings = Scalings(system, 0.0, 1.0, 1.0)
     # Initialize (very random) parameters
-    c6s = np.array([2.5, 27.0, 18.0, 13.0])
+    cns = np.array([2.5, 27.0, 18.0, 13.0])
     bs = np.array([2.5, 2.0, 0.0, 1.8])
     vols = np.array([5, 3, 4, 5])*angstrom**3
     # Allocate some arrays
     assert system.nffatype == 4
-    c6_cross = np.zeros((4, 4), float)
+    cn_cross = np.zeros((4, 4), float)
     b_cross = np.zeros((4, 4), float)
     # Construct the pair potential and part
-    pair_pot = PairPotDampDisp(system.ffatype_ids, c6_cross, b_cross, 9*angstrom, None, c6s, bs, vols)
+    pair_pot = PairPotDampDisp(system.ffatype_ids, cn_cross, b_cross, 9*angstrom, None, cns, bs, vols, power=power)
     part_pair = ForcePartPair(system, nlist, scalings, pair_pot)
     # The pair function
     def pair_fn(i0, i1, d):
-        c60 = c6s[system.ffatype_ids[i0]]
-        c61 = c6s[system.ffatype_ids[i1]]
+        cn0 = cns[system.ffatype_ids[i0]]
+        cn1 = cns[system.ffatype_ids[i1]]
         b0 = bs[system.ffatype_ids[i0]]
         b1 = bs[system.ffatype_ids[i1]]
         vol0 = vols[system.ffatype_ids[i0]]
         vol1 = vols[system.ffatype_ids[i1]]
         ratio = vol0/vol1
-        c6 = 2*c60*c61/(c60/ratio+c61*ratio)
+        cn = 2*cn0*cn1/(cn0/ratio+cn1*ratio)
         if b0 != 0 and b1 != 0:
             b = 0.5*(b0+b1)
             damp = 0
             fac = 1
-            for k in xrange(7):
+            for k in xrange(power+1):
                 damp += (b*d)**k/fac
                 fac *= k+1
             damp = 1 - np.exp(-b*d)*damp
-            return -c6/d**6*damp
+            return -cn/d**power*damp
         else:
             damp = 1
-            return -c6/d**6
+            return -cn/d**power
     return system, nlist, scalings, part_pair, pair_fn
 
 
 def test_pair_pot_dampdisp_caffeine_9A():
     system, nlist, scalings, part_pair, pair_fn = get_part_caffeine_dampdisp_9A()
+    check_pair_pot_caffeine(system, nlist, scalings, part_pair, pair_fn, 1e-15)
+
+
+def test_pair_pot_dampdisp8_caffeine_9A():
+    system, nlist, scalings, part_pair, pair_fn = get_part_caffeine_dampdisp_9A(power=8)
+    check_pair_pot_caffeine(system, nlist, scalings, part_pair, pair_fn, 1e-15)
+
+
+def test_pair_pot_dampdisp10_caffeine_9A():
+    system, nlist, scalings, part_pair, pair_fn = get_part_caffeine_dampdisp_9A(power=10)
     check_pair_pot_caffeine(system, nlist, scalings, part_pair, pair_fn, 1e-15)
 
 
@@ -1273,7 +1283,7 @@ def test_bks_isfinite():
     system = get_system_quartz()
     fn_pars = context.get_fn('test/parameters_bks.txt')
     ff = ForceField.generate(system, fn_pars)
-    assert np.isfinite(ff.part_pair_dampdisp.pair_pot.c6_cross).all()
+    assert np.isfinite(ff.part_pair_dampdisp.pair_pot.cn_cross).all()
     assert np.isfinite(ff.part_pair_dampdisp.pair_pot.b_cross).all()
     ff.compute()
     assert np.isfinite(ff.part_pair_exprep.energy)


### PR DESCRIPTION
Extended dispersion with Tang-Toennies damping to arbitrary powers of (1/r).
The case (1/r)^8 is needed for MEDFF.
The new implementation is marginally less efficient for the case (1/r)^6, but added computational time is insignificant.