### PR TITLE
Fix iter_matches for single atoms

### DIFF
--- a/yaff/system.py
+++ b/yaff/system.py
@@ -1099,7 +1099,7 @@ class System(object):
             both bonded or nearby the last matched pair.
             """
             from molmod.graphs import Graph
-            return Graph(system.bonds).distances
+            return Graph(system.bonds, system.natom).distances
 
         def error_sq_fn(x, y):
             """Compare bonded versus not bonded, rather than the full graph distance.

--- a/yaff/test/test_system.py
+++ b/yaff/test/test_system.py
@@ -481,3 +481,13 @@ def test_iter_matches_nobornane_rhodium():
     selected = set(system.iter_matches(system_ref).next())
     reference = set([77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95])
     np.testing.assert_equal(selected, reference)
+
+
+def test_iter_matches_single_atom():
+    system = System.from_file(context.get_fn('test/rhodium_complex_nobornane.xyz'))
+    system.detect_bonds()
+    system_ref = System(pos=np.zeros((1, 3), float), numbers = np.array([45]))
+    system_ref.detect_bonds()
+    selected = set(system.iter_matches(system_ref).next())
+    reference = set([28])
+    np.testing.assert_equal(selected, reference)


### PR DESCRIPTION
When using iter_matches to find a single atom, it doesn't find anything. This patch fixes that problem.