### PR TITLE
fix specifying of read-only mode in test_h5_flush

### DIFF
--- a/yaff/sampling/test/test_io.py
+++ b/yaff/sampling/test/test_io.py
@@ -51,14 +51,14 @@ def test_h5_flush():
             # 1) Check that we can't read the trajectory group in the h5 file without flushing.
             # This must be done in a subprocess, otherwise the HDF5 library will fake
             # flushing while it does not really flush to disk.
-            command = ['python', '-c', 'import h5py as h5; f = h5.File(\'%s/output.h5\', 'r'); f.close()' % dn_tmp]
+            command = ['python', '-c', 'import h5py as h5; f = h5.File("%s/output.h5", "r"); f.close()' % dn_tmp]
             p = Popen(command, stdout=PIPE, stderr=STDOUT)
             output = p.communicate()[0]
             assert 'IOError' in output
             assert p.returncode != 0
 
             # 2) This should work in a subprocess.
-            command = ['python', '-c', 'import h5py as h5; f = h5.File(\'%s/output_flushed.h5\', 'r'); f.close()' % dn_tmp]
+            command = ['python', '-c', 'import h5py as h5; f = h5.File("%s/output_flushed.h5", "r"); f.close()' % dn_tmp]
             p = Popen(command, stdout=PIPE, stderr=STDOUT)
             output = p.communicate()[0]
             assert 'IOError' not in output


### PR DESCRIPTION
@tovrstra I took a closer look at the failing `test_h5_flush` test, and I think the test is buggy...

The single quotes around `r` to specify read-only mode were missing.
You would expect that this results in a syntax error or so, but in this case you actually end up with valid Python code, because `r'...'` is a raw string, and concatenating strings like `'...' r'...'` is valid in Python:

```
>>> 'test'r'foo'
'testfoo'
```

I figured this out by checking what's in `output` for the failing part of the test:

```
======================================================================
FAIL: yaff.sampling.test.test_io.test_h5_flush
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/apps/gent/CO7/sandybridge/software/Python/2.7.13-intel-2017a/lib/python2.7/site-packages/nose-1.3.7-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/vsc40023/easybuild_build/yaff/1.1.1/intel-2017a-Python-2.7.13/yaff-1.1.1/yaff/sampling/test/test_io.py", line 65, in test_h5_flush
    assert 'IOError' not in output
AssertionError:
-------------------- >> begin captured stdout << ---------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/apps/gent/CO7/sandybridge/software/h5py/2.7.0-intel-2017a-Python-2.7.13/lib/python2.7/site-packages/h5py-2.7.0-py2.7-linux-x86_64.egg/h5py/_hl/files.py", line 271, in __init__
    fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)
  File "/apps/gent/CO7/sandybridge/software/h5py/2.7.0-intel-2017a-Python-2.7.13/lib/python2.7/site-packages/h5py-2.7.0-py2.7-linux-x86_64.egg/h5py/_hl/files.py", line 126, in make_fid
    fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/vsc40003/easybuild/h5py/2.7.0/intel-2017a-Python-2.7.13/h5py-2.7.0/h5py/_objects.c:3185)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/vsc40003/easybuild/h5py/2.7.0/intel-2017a-Python-2.7.13/h5py-2.7.0/h5py/_objects.c:3143)
  File "h5py/h5f.pyx", line 98, in h5py.h5f.create (/tmp/vsc40003/easybuild/h5py/2.7.0/intel-2017a-Python-2.7.13/h5py-2.7.0/h5py/h5f.c:2645)
IOError: Unable to create file (Unable to open file: name = '/tmp/eb-i8tdet/nve_water_321z4enayaff/output_flushed.h5', errno = 17, error message = 'file exists', flags = 15, o_flags = c2)


--------------------- >> end captured stdout << ----------------------
```

The `file exists` error only makes sense when the file is being opened in write mode, which is the default...

I'm not sure how this test could have ever passed?