### PR TITLE
More efficient neighborlist construction when some atoms are excluded

### DIFF
--- a/yaff/pes/nlist.c
+++ b/yaff/pes/nlist.c
@@ -36,6 +36,8 @@ int nlist_build_low(double *pos, double rcut, long *rmax,
   int update_delta0, image, sign;
   double delta0[3], delta[3], d;
 
+  // Compute square of the rcut distance
+  rcut *= rcut;
   r = status;
   a = status[3];
   b = status[4];
@@ -72,8 +74,10 @@ int nlist_build_low(double *pos, double rcut, long *rmax,
         delta[1] = sign*delta0[1];
         delta[2] = sign*delta0[2];
         cell_add_vec(delta, unitcell, r);
-        // Compute the distance and store the record if distance is below the rcut.
-        d = sqrt(delta[0]*delta[0] + delta[1]*delta[1] + delta[2]*delta[2]);
+        // Compute square of the distance and store the record if distance is below the rcut.
+        // Square root is only computed if the record needs to be stored,
+        // this way we avoid expensive square root in a lot of cases.
+        d = delta[0]*delta[0] + delta[1]*delta[1] + delta[2]*delta[2];
         if (d < rcut) {
           if (sign > 0) {
             (*neighs).a = a;
@@ -82,7 +86,7 @@ int nlist_build_low(double *pos, double rcut, long *rmax,
             (*neighs).a = b;
             (*neighs).b = a;
           }
-          (*neighs).d = d;
+          (*neighs).d = sqrt(d);
           (*neighs).dx = delta[0];
           (*neighs).dy = delta[1];
           (*neighs).dz = delta[2];

--- a/yaff/pes/nlist.py
+++ b/yaff/pes/nlist.py
@@ -156,6 +156,10 @@ class NeighborList(object):
                         raise ValueError('Atom density too high')
                 # 1) make an initial status object for the neighbor list algorithm
                 status = nlist_status_init(self.rmax)
+                # The atom index of the first atom in pair is always at least
+                # n_frame. The following status initialization avoids searching
+                # for frame-frame atom pairs in the neighbourlist build
+                status[3] = self.n_frame
                 # 2) a loop of consecutive update/allocate calls
                 last_start = 0
                 while True:


### PR DESCRIPTION
Improve the efficiency of the neighborlist construction
1) Only compute expensive square root if atom pair is in the neighborlist
2) Do not consider framework-framework pairs when those interaction are excluded