### PR TITLE
Lammps library bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   # Install more recent stuff with pip
   - pip install codecov coverage
   # Install LAMMPS
-  - conda install -c conda-forge lammps
+  - conda install -c conda-forge lammps=2018.12.12
   # Show conda info for debugging
   - conda info -a
 


### PR DESCRIPTION
This PR fixes a memory leak and a concurrency issue in the Lammps library interface. Unfortunately such mistakes are hard to detect with the current unit tests.