### PR TITLE
Include License in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include README
-include LICENSE.txt
+include README.rst
+include COPYING
 recursive-include doc *.rst *.png
 include doc/conf.py
 include doc/Makefile


### PR DESCRIPTION
While building the conda-forge package we noticed thatcher license is missing in the pypi package.

https://github.com/conda-forge/staged-recipes/pull/8889