### PR TITLE
Replace from scipy import random with from numpy import random

### DIFF
--- a/yaff/analysis/pca.py
+++ b/yaff/analysis/pca.py
@@ -30,7 +30,7 @@ import h5py as h5
 import numpy as np
 import scipy.linalg as spla
 import matplotlib.pyplot as pt
-from scipy import random
+from numpy import random
 
 from molmod.units import *
 from molmod.constants import boltzmann


### PR DESCRIPTION
Required for scipy 1.9.0 compatibility https://docs.scipy.org/doc/scipy/release.1.9.0.html#expired-deprecations